### PR TITLE
Flush before syncing when compressing log files

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -507,18 +507,27 @@ func compressLogFile(src, dst string) (err error) {
 		return err
 	}
 
+	// Flush the gz writer before Sync()ing
+	if err := gz.Flush(); err != nil {
+		return err
+	}
+
 	// fsync is important, otherwise os.Rename could rename a zero-length file
 	if err := gzf.Sync(); err != nil {
 		return err
 	}
 
+	// Close the gzip writer
 	if err := gz.Close(); err != nil {
 		return err
 	}
+
+	// close the underlying gzip file
 	if err := gzf.Close(); err != nil {
 		return err
 	}
 
+	// close the source file we copied from
 	if err := f.Close(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Ensure we flush the gzip writer before syncing the underlying file object, and before closing the writer and file.