### PR TITLE
permissions: allow to set custom permission bits on log files

### DIFF
--- a/linux_test.go
+++ b/linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package lumberjack
@@ -171,8 +172,8 @@ func TestCompressMaintainOwner(t *testing.T) {
 	// a compressed version of the log file should now exist with the correct
 	// owner.
 	filename2 := backupFile(dir)
-	equals(555, fakeFS.files[filename2+compressSuffix].uid, t)
-	equals(666, fakeFS.files[filename2+compressSuffix].gid, t)
+	equals(555, fakeFS.files[filename2+compressSuffix+tmpSuffix].uid, t)
+	equals(666, fakeFS.files[filename2+compressSuffix+tmpSuffix].gid, t)
 }
 
 type fakeFile struct {

--- a/lumberjack.go
+++ b/lumberjack.go
@@ -3,7 +3,7 @@
 // Note that this is v2.0 of lumberjack, and should be imported using gopkg.in
 // thusly:
 //
-//   import "gopkg.in/natefinch/lumberjack.v2"
+//	import "gopkg.in/natefinch/lumberjack.v2"
 //
 // The package name remains simply lumberjack, and the code resides at
 // https://github.com/natefinch/lumberjack under the v2.0 branch.
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -67,7 +68,7 @@ var _ io.WriteCloser = (*Logger)(nil)
 // `/var/log/foo/server.log`, a backup created at 6:30pm on Nov 11 2016 would
 // use the filename `/var/log/foo/server-2016-11-04T18-30-00.000.log`
 //
-// Cleaning Up Old Log Files
+// # Cleaning Up Old Log Files
 //
 // Whenever a new logfile gets created, old log files may be deleted.  The most
 // recent files according to the encoded timestamp will be retained, up to a
@@ -107,6 +108,10 @@ type Logger struct {
 	// Compress determines if the rotated log files should be compressed
 	// using gzip. The default is not to perform compression.
 	Compress bool `json:"compress" yaml:"compress"`
+
+	// FileMode is the file's mode and permission bits of the log file. If set
+	// it will be used as the specified mode.
+	FileMode fs.FileMode
 
 	size int64
 	file *os.File
@@ -214,6 +219,11 @@ func (l *Logger) openNew() error {
 
 	name := l.filename()
 	mode := os.FileMode(0644)
+
+	if l.fileModeIsSet() {
+		mode = l.FileMode
+	}
+
 	info, err := osStat(name)
 	if err == nil {
 		// Copy the mode off the old logfile.
@@ -296,6 +306,16 @@ func (l *Logger) filename() string {
 	}
 	name := filepath.Base(os.Args[0]) + "-lumberjack.log"
 	return filepath.Join(os.TempDir(), name)
+}
+
+// fileModeIsSet checks if the file mode of the log file was set. If so
+// it returns true. It does not validate the mode.
+func (l *Logger) fileModeIsSet() bool {
+	if uint32(l.FileMode) != 0 {
+		return true
+	}
+
+	return false
 }
 
 // millRunOnce performs compression and removal of stale log files.


### PR DESCRIPTION
This adds the FileMode field to allow setting custom permission bits
on log files. We have use cases where the logs should be viewed only
by privileged.
    
This custom FileMode is used only if set by callers. It does not
perform validation on the passed permissions and code is kept minimal.
Callers should know what to pass.
    
Signed-off-by: Djalal Harouni <tixxdz@gmail.com>