### PR TITLE
Fix tests by only flushing gzip writer once

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -507,18 +507,17 @@ func compressLogFile(src, dst string) (err error) {
 		return err
 	}
 
-	// Flush the gz writer before Sync()ing
-	if err := gz.Flush(); err != nil {
+	// Close the gzip writer.
+	// Closing also triggers a Flush to the underlying
+	// io.Writer, and doesnot close the underlying io.Writer.
+	// We must Close() or Flush() the gz writer before Sync()ing otherwise we may
+	// see partially written data and a corrupt gzip archive.
+	if err := gz.Close(); err != nil {
 		return err
 	}
 
 	// fsync is important, otherwise os.Rename could rename a zero-length file
 	if err := gzf.Sync(); err != nil {
-		return err
-	}
-
-	// Close the gzip writer
-	if err := gz.Close(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Closing the gzip writer causes a flush, and doesn't actually close the underlying file, so we can switch to closing the gzip writer before closing the underlying file, instead of using Flush(). The previous approach of Flushing and then Closing caused us to flush twice, which had the side-effect of causing the underlying file to have an additional 5 bytes of data that was not expected in our tests.