### PR TITLE
chown: fix missing function on non-linux OS

### DIFF
--- a/chown.go
+++ b/chown.go
@@ -9,3 +9,7 @@ import (
 func chown(_ string, _ os.FileInfo) error {
 	return nil
 }
+
+func chownWithMode(_ string, _ os.FileInfo, _ os.FileMode) error {
+	return nil
+}


### PR DESCRIPTION
In https://github.com/cilium/lumberjack/pull/5, we introduced a new `chownWithMode` func in `chown_linux.go` and forgot to add it as well for non-linux OS.

CC @lambdanis